### PR TITLE
rename method

### DIFF
--- a/malio-processor/src/main/java/com/github/nalukit/malio/processor/constraints/generator/ConstraintBlacklistGenerator.java
+++ b/malio-processor/src/main/java/com/github/nalukit/malio/processor/constraints/generator/ConstraintBlacklistGenerator.java
@@ -63,7 +63,7 @@ public class ConstraintBlacklistGenerator
                                           .toString();
     String[] blacklist   = variableElement.getAnnotation(Blacklist.class)
                                           .value();
-    String   arraySyntax = processorUtils.createStringInitializationFromArray(blacklist);
+    String   arraySyntax = processorUtils.createStringInitFromArray(blacklist);
     typeSpec.addMethod(MethodSpec.constructorBuilder()
                                  .addModifiers(Modifier.PUBLIC)
                                  .addStatement("super($S, $S, $S, $L)",

--- a/malio-processor/src/main/java/com/github/nalukit/malio/processor/constraints/generator/ConstraintWhitelistGenerator.java
+++ b/malio-processor/src/main/java/com/github/nalukit/malio/processor/constraints/generator/ConstraintWhitelistGenerator.java
@@ -61,7 +61,7 @@ public class ConstraintWhitelistGenerator
                                           .toString();
     String[] whitelist   = variableElement.getAnnotation(Whitelist.class)
                                           .value();
-    String   arraySyntax = processorUtils.createStringInitializationFromArray(whitelist);
+    String   arraySyntax = processorUtils.createStringInitFromArray(whitelist);
     typeSpec.addMethod(MethodSpec.constructorBuilder()
                                  .addModifiers(Modifier.PUBLIC)
                                  .addStatement("super($S, $S, $S, $L)",

--- a/malio-processor/src/main/java/com/github/nalukit/malio/processor/util/ProcessorUtils.java
+++ b/malio-processor/src/main/java/com/github/nalukit/malio/processor/util/ProcessorUtils.java
@@ -133,7 +133,7 @@ public class ProcessorUtils {
                         .toUpperCase() + value.substring(1);
   }
 
-  public String createStringInitializationFromArray(String[] array) {
+  public String createStringInitFromArray(String[] array) {
     String[] newArray = new String[array.length];
     for (int i = 0; i < array.length; i++) {
       newArray[i] = String.format("\"%s\"",


### PR DESCRIPTION
I suggest to rename `createStringInitializationFromArray` as `createStringInitFromArray` by replacing full term `Initialization` with its well-known abbreviation. In addition, `Init` is also used in this project. This abbreviation is common and well-known, and thus employing this well-known abbreviation would not result in confusion, but may improve the readability of the source code.

Accordingly, I have renamed the method by applying rename method refactoring, and submitted the PR. No other changes are involved in the PR.

Would you please kindly review the PR. Thanks.